### PR TITLE
Implemented sparse QR decomposition

### DIFF
--- a/src/FSharp.Stats/Algebra/LinearAlgebraServiceManaged.fs
+++ b/src/FSharp.Stats/Algebra/LinearAlgebraServiceManaged.fs
@@ -148,7 +148,6 @@ module LinearAlgebraManaged =
         (((*P.Length,*)Permutation.ofArray P),L + Matrix.identity nA,U)
         //(P, L + (Matrix.identity nA), U)
     
-
     /// Solves a system of linear equations, AX = B, with A LU factorized.
     let SolveLinearSystem (A:matrix) (b:vector) =
         let (n,m) = matrixDims A
@@ -192,10 +191,32 @@ module LinearAlgebraManaged =
             for k=i to m-1 do
                 A.[l,k] <- A.[l,k] - 2.0 * v.[l-i] * v'A.[k-i]
         v                                                              // Return reflection vector.
-            
-    let QR (A:matrix) =
+    
+    type SparseEntry (index:int, value:float) =
+        member m.index = index
+        member val value = value with get, set
+
+    type SparseVector() = 
+        member val entries = new ResizeArray<SparseEntry>() with get,set
+        member m.Front =
+            m.entries.[0]
+        member m.Add (entry:SparseEntry) =
+            m.entries.Add(entry)
+        member m.IsEmpty =
+            m.entries.Count <= 0
+        member m.Swap (other:SparseVector) =
+            let temp = new ResizeArray<SparseEntry> (other.entries)
+            other.entries <- new ResizeArray<SparseEntry>(m.entries)
+            m.entries <- new ResizeArray<SparseEntry>(temp)
+        member m.PopFront =
+            let value = m.entries.[0]
+            m.entries.RemoveAt(0)
+            value
+
+    /// QR factorization function for dense matrices
+    let QRDense (A:matrix) =
         let (n,m) = matrixDims A
-        let mutable Q = Matrix.identity n                                   // Keeps track of the orthogonal matrix.
+        let mutable Q = Matrix.identity n // Keeps track of the orthogonal matrix.
         let R = Matrix.copy A
 
         // This method will update the orhogonal transformation fast when given a reflection vector.
@@ -218,6 +239,172 @@ module LinearAlgebraManaged =
             let v = HouseholderTransform R i
             UpdateQ Q v
         Q,R
+
+    /// QR factorization function for sparse matrices, returns Q as a product of givens rotations and R as upper triangular
+    let QRSparse(A:SparseMatrix<float>) =
+        
+        // Copies the row of a Sparsematrix into a Sparsevector
+        let CopyRow(nnz:int, offset:int, A:SparseMatrix<float>) =
+            let sparseVector = SparseVector()
+            for i=nnz-1 downto 0 do
+                if(not (A.SparseValues.[i+offset] = 0.0)) then
+                    let entry = SparseEntry(A.SparseColumnValues.[i+offset], A.SparseValues.[i+offset])
+                    sparseVector.entries.Insert(0, entry)
+            sparseVector
+        
+        // Returns "value" with the sign of "sign"
+        let Copysign(value:float, sign:float) =
+            if (sign >= 0.0) then
+                abs(value)
+            else // sign is negative
+                if(value < 0.0) then
+                    value
+                else
+                   value * -1.0
+
+        let encode(c:float, s:float) = 
+            if(abs(s) < c) then
+                s
+            else
+                Copysign(1.0/c, s)
+
+        // Apply the givens rotation on 2 Sparsevectors
+        let applyGivens( x : SparseVector, y : SparseVector) = 
+            let a = x.Front.value
+            let b = y.Front.value
+    
+            let mutable c = -1.0
+            let mutable s = -1.0
+
+            if (b = 0.0) then
+              c <- 1.0
+              s <- 0.0
+            else
+                if (abs(b) > abs(a)) then
+                    let tau = -a / b
+                    s <- 1.0 / sqrt(1.0 + tau * tau)
+                    c <- s * tau
+                    if (c < 0.0) then 
+                        c <- -c
+                        s <- -s
+                else
+                    let tau = -b/a
+                    c <- 1.0 / sqrt(1.0 + tau * tau)
+                    s <- c * tau
+
+            // rotate the start of each list
+            x.Front.value <- c * a - s * b
+            y.PopFront |> ignore
+    
+            // Iterators
+            let mutable p = 0
+            let mutable q = 0
+            p <- p + 1 // Skip the first entry since we already handled it above
+    
+            while (p < x.entries.Count && q < y.entries.Count) do
+                if (x.entries.[p].index = y.entries.[q].index) then
+                    let xNew = c  * x.entries.[p].value - s * y.entries.[q].value
+                    let yNew = s *  x.entries.[p].value + c * y.entries.[q].value
+                    if (not (xNew = 0.0)) then
+                        x.entries.[p].value <- xNew
+                        p <- p + 1
+                    else
+                        x.entries.RemoveAt(p)
+                    if ( not (yNew = 0.0)) then
+                        y.entries.[q].value <- yNew
+                        q <- q + 1
+                    else
+                        y.entries.RemoveAt(q)
+                else if(x.entries.[p].index < y.entries.[q].index) then
+                    let k = x.entries.[p].index
+                    let xNew = c * x.entries.[p].value
+                    let yNew = s * x.entries.[p].value
+                    x.entries.[p].value <- xNew
+                    p <-p + 1
+                    y.entries.Insert(q, SparseEntry(k, yNew))
+                    q <- q + 1
+                else
+                    let k = y.entries.[q].index
+                    let xNew= -s * y.entries.[q].value
+                    let yNew= c * y.entries.[q].value
+                    x.entries.Insert(p,SparseEntry(k, xNew))
+                    p <- p + 1
+                    y.entries.[q].value <- yNew
+                    q <- q + 1
+            if(p < x.entries.Count) then
+                while(p < x.entries.Count) do
+                    let k = x.entries.[p].index
+                    let xNew = c * x.entries.[p].value
+                    let yNew = s * x.entries.[p].value
+                    x.entries.[p].value <- xNew
+                    p <- p + 1
+                    y.entries.Insert(q,SparseEntry(k, yNew))
+                    q <- q + 1      
+            else if(q < y.entries.Count) then
+                while(q < y.entries.Count) do
+                    let k = y.entries.[q].index
+                    let xNew = -s * y.entries.[q].value
+                    let yNew = c * y.entries.[q].value
+                    x.entries.Insert(p,SparseEntry(k, xNew))
+                    p <- p + 1
+                    y.entries.[q].value <- yNew
+                    q <- q + 1
+
+            encode(c, s)
+        
+        // Run Sparse QR
+        let m = A.NumRows
+        let n = A.NumCols
+        let mutable Q = new ResizeArray<SparseVector>()
+        let mutable R = new ResizeArray<SparseVector>()
+   
+        for i = 0 to m - 1 do
+            Q.Add(SparseVector())
+            R.Add(SparseVector())
+
+        for a = 0 to m-1 do
+            let row = CopyRow(A.SparseRowOffsets.[a+1] - A.SparseRowOffsets.[a], A.SparseRowOffsets.[a], A)
+            let mutable q = 0
+            while((not row.IsEmpty) && row.Front.index < a && row.Front.index < n) do
+                let j = row.Front.index
+
+                if(R.[j].IsEmpty || R.[j].Front.index > j) then
+                    R.[j].Swap(row)
+                    Q.[a].entries.Insert(q, SparseEntry(j, 1.0))
+                    q <- q + 1
+                    ()
+                else
+                    let ret = applyGivens(R.[j], row)
+                    Q.[a].entries.Insert(q, SparseEntry(j, ret))
+                    q <- q + 1
+                    ()
+            if (a < n) then
+                R.[a].Swap(row)
+                ()
+
+        let mutable x = -1
+
+        let RSeq = seq{ for row in R do
+                            x <- x+1
+                            for entry in row.entries do
+                                yield(x, entry.index, float entry.value)}
+
+        let ROut = Matrix.initSparse m n RSeq
+
+        x <- -1
+        let QSeq = seq{ for row in Q do
+                            x <- x+1
+                            for entry in row.entries do
+                                yield(x, entry.index, float entry.value)}
+
+        let QOut = Matrix.initSparse m n QSeq
+        QOut, ROut
+
+    /// Matches the union type of the matrix and invokes the according QR factorization function
+    let QR (A:matrix) =
+        match A with
+            | SparseRepr A -> QRSparse(A)
+            | DenseRepr _ -> QRDense(A)
 
     let Hessenberg (A:matrix) =
         // REVIEW we can do with less copying here.
@@ -248,17 +435,53 @@ module LinearAlgebraManaged =
         Q,Matrix.init n m (fun i j -> if i = 0 then A.[i,j] else R.[i-1,j])
         
     let leastSquares A (b: vector) =
+
+        // Q.transpose * b for sparse Q
+        let MultiplyVectorWithTransposeGivensMatrix (q:SparseMatrix<float>, x:vector) =
+            let outVec = vector x
+            let m = q.NumRows
+            for i = 0 to m-1 do
+                for j = q.SparseRowOffsets.[i] to (q.SparseRowOffsets.[i+1] - 1) do
+                    let k = q.SparseColumnValues.[j]
+                    if(q.SparseValues.[j] = 1.0) then
+                        let temp = outVec.[i]
+                        outVec.[i] <- outVec.[k]
+                        outVec.[k] <- temp
+                    else
+                        let tau = q.SparseValues.[j]
+                        let mutable c = -1.0
+                        let mutable s = -1.0
+                        if(abs(tau) < 1.0) then
+                            s <- tau
+                            c <- sqrt(1.0-s*s)
+                        else
+                            c <- 1.0/tau
+                            s <- sqrt(1.0-c*c)
+                            if(c < 0.0) then
+                                c <- -c
+                                s <- -s
+                        let newxk = c * outVec.[k] - s * outVec.[i]
+                        outVec.[i] <- s * outVec.[k] + c * outVec.[i]
+                        outVec.[k] <- newxk
+            outVec
+    
         let (m,n) = matrixDims A
+        let Qm, R = QR A
+        let mutable Qtb = vector [||]
+
+        match Qm with
+            | DenseRepr _ ->
+                Qtb <- Qm.Transpose * b
+            | SparseRepr qm ->
+                Qtb <- MultiplyVectorWithTransposeGivensMatrix(qm, b)
+
         // Is this an overdetermined or underdetermined system?
         if m > n then
-            let qm,R = QR A
-            let Qtb = qm.Transpose * b
             SolveTriangularLinearSystem R.[0..n-1,0..n-1] Qtb.[0..n-1] false
         else
-            let qm,R = QR A
-            let Qtb = qm.Transpose * b
             let s = SolveTriangularLinearSystem R.[0..m-1,0..m-1] Qtb false
             Vector.init n (fun i -> if i < m then s.[i] else 0.0)
+       
 
     /// computes the hat matrix by the QR decomposition of the designmatrix used in ordinary least squares approaches
     let hatMatrix (designMatrix: Matrix<float>) = 
@@ -285,7 +508,7 @@ module LinearAlgebraManaged =
                                         )
         leverage
         
-    
+
     /// Calculates the pseudo inverse of the matrix
     let pseudoInvers (matrix:Matrix<float>) =
         let (m,n) = matrixDims matrix

--- a/src/FSharp.Stats/DotNetExtensions.fs
+++ b/src/FSharp.Stats/DotNetExtensions.fs
@@ -1,15 +1,16 @@
-﻿module DotNetExtensions
+﻿namespace FSharp.Stats
 
-open System.Collections.Generic
+module DotNetExtensions =
+    open System.Collections.Generic
 
-[<Extension>]
-type List<'T> with
-    member m.Front
-        with get() = m.[0]
-        and set(value : 'T) = m.[0] <- value
-    member m.PopFront =
-        let value = m.[0]
-        m.RemoveAt(0)
-        value
-    member m.IsEmpty =
-        m.Count <= 0
+    [<Extension>]
+    type List<'T> with
+        member m.Front
+            with get() = m.[0]
+            and set(value : 'T) = m.[0] <- value
+        member m.PopFront =
+            let value = m.[0]
+            m.RemoveAt(0)
+            value
+        member m.IsEmpty =
+            m.Count <= 0

--- a/src/FSharp.Stats/DotNetExtensions.fs
+++ b/src/FSharp.Stats/DotNetExtensions.fs
@@ -1,0 +1,15 @@
+﻿module DotNetExtensions
+
+open System.Collections.Generic
+
+[<Extension>]
+type List<'T> with
+    member m.Front
+        with get() = m.[0]
+        and set(value : 'T) = m.[0] <- value
+    member m.PopFront =
+        let value = m.[0]
+        m.RemoveAt(0)
+        value
+    member m.IsEmpty =
+        m.Count <= 0

--- a/src/FSharp.Stats/FSharp.Stats.fsproj
+++ b/src/FSharp.Stats/FSharp.Stats.fsproj
@@ -18,6 +18,7 @@
     <EmbeddedResource Remove="Scripts\**" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DotNetExtensions.fs" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Ops.fs" />
     <Compile Include="Random.fs" />


### PR DESCRIPTION
This is the implementation of a QR decomposition using the givens rotation method.

A sum up of the changes:

- Added the function QRSparse which calculates the factorization for a given SpraseMatrix<float>
- Altered the leastSquares function to handle the correct multiplication of the vector with the transpose of Q in case Q is the result of a Sparse factorization. This needs to be done because the Q resulting from QRSParse is a product of givens rotations other than the "regular" dense Q.
- Added DotNetExtions.fs which, for now, extends the .net generic list with some generally useful functions that I needed in order to keep the QRSparse code clean.
- The "QR" function now pattern matches the union type of the given matrix and calls the according QR function (QRDense or QRSparse)

Feel free to give me any kind of feedback or suggestions.